### PR TITLE
SYAL-3254: Reboot control follow-up fixes

### DIFF
--- a/src/main/java/com/avispl/symphony/dal/communicator/Constants.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/Constants.java
@@ -54,6 +54,11 @@ public interface Constants {
         String ADD_TAG = "DeviceTags#AddTag";
         String REMOVE_TAG = "DeviceTags#RemoveAll";
         String REBOOT = "Reboot";
+        /**
+         * Must match the {@code gracePeriod} value declared for the Reboot control in both
+         * src/main/resources/mapping/model-mapping.yml and src/test/resources/mappings/model-mapping.yml.
+         * */
+        long REBOOT_GRACE_PERIOD_SECONDS = 180L;
         String API_CAPABILITIES = "APICapabilities";
         String API_PERMISSIONS = "APIPermissions";
         String TAGS = "DeviceTags#Tags";

--- a/src/main/java/com/avispl/symphony/dal/communicator/Constants.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/Constants.java
@@ -73,6 +73,7 @@ public interface Constants {
         String AVAILABLE_PROPERTY_GROUPS = "AvailableDevicesPropertyGroups#";
         String STATUS = "Status";
         String STATUS_GROUP = "Status#";
+        String DEVICE_STATE = "SystemUnit#State";
         String LAST_UPDATED = "LastUpdated";
         String DEVICE_TAGS = "DeviceTags";
         String CONFIGURATION = "Configuration";

--- a/src/main/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicator.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicator.java
@@ -1768,11 +1768,12 @@ public class WebExControlHubAggregatorCommunicator extends RestCommunicator impl
      * @param aggregatedDevice device to update controls for
      * */
     private void updateRebootControl(AggregatedDevice aggregatedDevice) {
-        List<AdvancedControllableProperty> controls = aggregatedDevice.getControllableProperties();
+        List<AdvancedControllableProperty> controls = new ArrayList<>(aggregatedDevice.getControllableProperties());
         Map<String, String> properties = aggregatedDevice.getProperties();
 
         if (!supportsXapiCommands(aggregatedDevice)) {
             controls.removeIf(control -> Constants.PropertyNames.REBOOT.equals(control.getName()));
+            aggregatedDevice.setControllableProperties(controls);
             properties.remove(Constants.PropertyNames.REBOOT);
             return;
         }
@@ -1780,6 +1781,14 @@ public class WebExControlHubAggregatorCommunicator extends RestCommunicator impl
         if (!properties.containsKey(Constants.PropertyNames.REBOOT)) {
             properties.put(Constants.PropertyNames.REBOOT, "Reboot");
         }
+        if (controls.stream().noneMatch(control -> Constants.PropertyNames.REBOOT.equals(control.getName()))) {
+            AdvancedControllableProperty.Button button = new AdvancedControllableProperty.Button();
+            button.setLabel("Reboot");
+            button.setLabelPressed("Rebooting");
+            button.setGracePeriod(Constants.PropertyNames.REBOOT_GRACE_PERIOD_SECONDS);
+            controls.add(new AdvancedControllableProperty(Constants.PropertyNames.REBOOT, new Date(), button, "Reboot"));
+        }
+        aggregatedDevice.setControllableProperties(controls);
     }
 
     /**

--- a/src/main/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicator.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicator.java
@@ -1427,6 +1427,8 @@ public class WebExControlHubAggregatorCommunicator extends RestCommunicator impl
             String teamsState = elements.at(Constants.CallIndicators.MS_EXTENSION_IN_CALL).asText();
             String teamsNewState = elements.at(Constants.CallIndicators.MS_TEAMS_IN_CALL).asText();
 
+            deviceProperties.put(Constants.PropertyNames.DEVICE_STATE, systemState);
+
             assignDeviceInCallStatus(aggregatedDevice, Objects.equals(Constants.States.IN_CALL, systemState)
                     || Objects.equals(Constants.States.TRUE, teamsState) || Objects.equals(Constants.States.TRUE, teamsNewState));
         } catch (Exception ex) {

--- a/src/main/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicator.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicator.java
@@ -1730,7 +1730,15 @@ public class WebExControlHubAggregatorCommunicator extends RestCommunicator impl
 
         Map<String, String> request = new HashMap<>();
         request.put("deviceId", deviceId);
-        doPost(Constants.URL.DEVICE_CONTROL + Constants.URL.XAPI_BOOT_COMMAND, request, JsonNode.class);
+        try {
+            doPost(Constants.URL.DEVICE_CONTROL + Constants.URL.XAPI_BOOT_COMMAND, request, JsonNode.class);
+        } catch (CommandFailureException e) {
+            logger.error(String.format("WebEx API error %s while rebooting device %s", e.getStatusCode(), deviceId), e);
+            if (e.getStatusCode() == HttpStatus.CONFLICT.value()) {
+                throw new IllegalStateException(String.format("Unable to reboot the device '%s', please check the device state.", aggregatedDevice.getDeviceName()));
+            }
+            throw new IllegalStateException(String.format("Unable to reboot '%s': the reboot command failed.", aggregatedDevice.getDeviceName()));
+        }
     }
 
     /**

--- a/src/main/resources/mapping/model-mapping.yml
+++ b/src/main/resources/mapping/model-mapping.yml
@@ -37,7 +37,7 @@ models:
       control:
         Reboot:
           type: Button
-          gracePeriod: 60
+          gracePeriod: 180
           label: Reboot
           labelPressed: Rebooting
         DeviceTags#RemoveAll:

--- a/src/test/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicatorTest.java
+++ b/src/test/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicatorTest.java
@@ -3,6 +3,7 @@
  */
 package com.avispl.symphony.dal.communicator;
 
+import com.avispl.symphony.api.dal.dto.control.AdvancedControllableProperty;
 import com.avispl.symphony.api.dal.dto.control.ControllableProperty;
 import com.avispl.symphony.api.dal.dto.monitor.ExtendedStatistics;
 import com.avispl.symphony.api.dal.dto.monitor.Statistics;
@@ -11,6 +12,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -120,6 +125,56 @@ public class WebExControlHubAggregatorCommunicatorTest {
         controllableProperty.setProperty(Constants.PropertyNames.REBOOT);
         controllableProperty.setDeviceId(device.getDeviceId());
         communicator.controlProperty(controllableProperty);
+    }
+
+    /**
+     * Regression test for updateRebootControl(): once the Reboot button control is removed because a
+     * device stops supporting xAPI commands, it must be re-added once xAPI support is detected again.
+     * Invoked via reflection since updateRebootControl() is private and this test targets it directly
+     * without going through any network call.
+     *
+     * Initial controllableProperties is seeded with a Reboot Button already present, matching what
+     * aggregatedDeviceProcessor.extractDevices() produces from the mapping before updateRebootControl()
+     * ever runs in production, rather than starting from an empty list.
+     * */
+    @Test
+    public void testUpdateRebootControlReAddsButtonAfterXapiSupportRestored() throws Exception {
+        AggregatedDevice device = new AggregatedDevice();
+        device.setDeviceId("test-device-id");
+        device.setDeviceOnline(true);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Constants.PropertyNames.API_CAPABILITIES, "[xapi]");
+        properties.put(Constants.PropertyNames.API_PERMISSIONS, "[xapi]");
+        properties.put(Constants.PropertyNames.REBOOT, "Reboot");
+        device.setProperties(properties);
+
+        AdvancedControllableProperty.Button button = new AdvancedControllableProperty.Button();
+        button.setLabel("Reboot");
+        button.setLabelPressed("Rebooting");
+        button.setGracePeriod(Constants.PropertyNames.REBOOT_GRACE_PERIOD_SECONDS);
+        List<AdvancedControllableProperty> controllableProperties = new ArrayList<>();
+        controllableProperties.add(new AdvancedControllableProperty(Constants.PropertyNames.REBOOT, new Date(), button, "Reboot"));
+        device.setControllableProperties(controllableProperties);
+
+        Method updateRebootControl = WebExControlHubAggregatorCommunicator.class.getDeclaredMethod("updateRebootControl", AggregatedDevice.class);
+        updateRebootControl.setAccessible(true);
+
+        // Initial state, as produced by extractDevices() from the mapping: Reboot button present
+        Assertions.assertTrue(device.getControllableProperties().stream()
+                .anyMatch(control -> Constants.PropertyNames.REBOOT.equals(control.getName())));
+
+        // Device goes offline, no longer supports xAPI commands: Reboot button must be removed
+        device.setDeviceOnline(false);
+        updateRebootControl.invoke(communicator, device);
+        Assertions.assertTrue(device.getControllableProperties().stream()
+                .noneMatch(control -> Constants.PropertyNames.REBOOT.equals(control.getName())));
+
+        // Device comes back online, supports xAPI commands again: Reboot button must be re-added
+        device.setDeviceOnline(true);
+        updateRebootControl.invoke(communicator, device);
+        Assertions.assertTrue(device.getControllableProperties().stream()
+                        .anyMatch(control -> Constants.PropertyNames.REBOOT.equals(control.getName())),
+                "Reboot button should be re-added once the device supports xAPI commands again");
     }
 
     @Test

--- a/src/test/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicatorTest.java
+++ b/src/test/java/com/avispl/symphony/dal/communicator/WebExControlHubAggregatorCommunicatorTest.java
@@ -5,13 +5,17 @@ package com.avispl.symphony.dal.communicator;
 
 import com.avispl.symphony.api.dal.dto.control.AdvancedControllableProperty;
 import com.avispl.symphony.api.dal.dto.control.ControllableProperty;
+import com.avispl.symphony.api.dal.dto.monitor.EndpointStatistics;
 import com.avispl.symphony.api.dal.dto.monitor.ExtendedStatistics;
 import com.avispl.symphony.api.dal.dto.monitor.Statistics;
 import com.avispl.symphony.api.dal.dto.monitor.aggregator.AggregatedDevice;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Date;
@@ -175,6 +179,92 @@ public class WebExControlHubAggregatorCommunicatorTest {
         Assertions.assertTrue(device.getControllableProperties().stream()
                         .anyMatch(control -> Constants.PropertyNames.REBOOT.equals(control.getName())),
                 "Reboot button should be re-added once the device supports xAPI commands again");
+    }
+
+    /**
+     * Regression test for retrieveDeviceStatus(): the raw SystemUnit/State/System value read off the xAPI
+     * status response must be exposed under Constants.PropertyNames.DEVICE_STATE unconditionally, even when
+     * includePropertyGroups is empty and collectStatusProperties() would otherwise drop the SystemUnit group.
+     * Invoked via reflection since retrieveDeviceStatus() is private. The xAPI status response is stubbed by
+     * overriding doGet() on an anonymous subclass, and the background polling thread is stopped immediately
+     * after construction, so the test performs no network calls.
+     * */
+    @Test
+    public void testRetrieveDeviceStatusExposesDeviceStateWhenSleeping() throws Exception {
+        WebExControlHubAggregatorCommunicator testCommunicator = newNetworkFreeCommunicator(buildXapiStatusResponse("Sleeping"));
+        AggregatedDevice device = buildXapiCapableDevice("device-sleeping");
+
+        invokeRetrieveDeviceStatus(testCommunicator, device);
+
+        Assertions.assertEquals("Sleeping", device.getProperties().get(Constants.PropertyNames.DEVICE_STATE));
+        EndpointStatistics endpointStatistics = (EndpointStatistics) device.getMonitoredStatistics().get(0);
+        Assertions.assertFalse(endpointStatistics.isInCall(), "Device must not be marked in-call while Sleeping");
+    }
+
+    /**
+     * Companion to {@link #testRetrieveDeviceStatusExposesDeviceStateWhenSleeping()}: confirms the new
+     * DEVICE_STATE property does not affect the existing in-call detection when SystemUnit/State/System
+     * reports InCall.
+     * */
+    @Test
+    public void testRetrieveDeviceStatusKeepsInCallBehaviourWhenInCall() throws Exception {
+        WebExControlHubAggregatorCommunicator testCommunicator = newNetworkFreeCommunicator(buildXapiStatusResponse(Constants.States.IN_CALL));
+        AggregatedDevice device = buildXapiCapableDevice("device-in-call");
+
+        invokeRetrieveDeviceStatus(testCommunicator, device);
+
+        Assertions.assertEquals(Constants.States.IN_CALL, device.getProperties().get(Constants.PropertyNames.DEVICE_STATE));
+        EndpointStatistics endpointStatistics = (EndpointStatistics) device.getMonitoredStatistics().get(0);
+        Assertions.assertTrue(endpointStatistics.isInCall(), "Device must be marked in-call when SystemUnit/State/System is InCall");
+    }
+
+    private static JsonNode buildXapiStatusResponse(String systemState) throws Exception {
+        String json = "{\"result\":{\"SystemUnit\":{\"State\":{\"System\":\"" + systemState + "\"}}}}";
+        return new ObjectMapper().readTree(json);
+    }
+
+    private static AggregatedDevice buildXapiCapableDevice(String deviceId) {
+        AggregatedDevice device = new AggregatedDevice();
+        device.setDeviceId(deviceId);
+        device.setDeviceOnline(true);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Constants.PropertyNames.API_CAPABILITIES, "[xapi]");
+        properties.put(Constants.PropertyNames.API_PERMISSIONS, "[xapi]");
+        device.setProperties(properties);
+        return device;
+    }
+
+    /**
+     * Builds a communicator whose xAPI status response is stubbed via an overridden doGet() (so the request
+     * never leaves the JVM), and whose background polling thread is destroyed immediately after construction,
+     * before it can reach its first fetchDevicesList() call. devicePaused is then flipped to false directly,
+     * bypassing retrieveMultipleStatistics()/fetchDevicesList(), so doGetWithRetry() will actually invoke the
+     * stubbed doGet() instead of short-circuiting to null.
+     * */
+    private static WebExControlHubAggregatorCommunicator newNetworkFreeCommunicator(JsonNode statusResponse) throws Exception {
+        WebExControlHubAggregatorCommunicator testCommunicator = new WebExControlHubAggregatorCommunicator() {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected <Response> Response doGet(String uri, Class<Response> responseClass) throws Exception {
+                if (responseClass == JsonNode.class && uri.contains("xapi/status")) {
+                    return (Response) statusResponse;
+                }
+                throw new UnsupportedOperationException("Unexpected network call in test: " + uri);
+            }
+        };
+        testCommunicator.internalDestroy();
+
+        Field devicePausedField = WebExControlHubAggregatorCommunicator.class.getDeclaredField("devicePaused");
+        devicePausedField.setAccessible(true);
+        devicePausedField.set(testCommunicator, false);
+
+        return testCommunicator;
+    }
+
+    private static void invokeRetrieveDeviceStatus(WebExControlHubAggregatorCommunicator communicator, AggregatedDevice device) throws Exception {
+        Method retrieveDeviceStatus = WebExControlHubAggregatorCommunicator.class.getDeclaredMethod("retrieveDeviceStatus", AggregatedDevice.class);
+        retrieveDeviceStatus.setAccessible(true);
+        retrieveDeviceStatus.invoke(communicator, device);
     }
 
     @Test

--- a/src/test/resources/mappings/model-mapping.yml
+++ b/src/test/resources/mappings/model-mapping.yml
@@ -34,7 +34,7 @@ models:
       control:
         Reboot:
           type: Button
-          gracePeriod: 60
+          gracePeriod: 180
           label: Reboot
           labelPressed: Rebooting
         DeviceTags#RemoveAll:


### PR DESCRIPTION
Follow-up on the reboot feature merged via PR #19, addressing QA feedback on SYAL-3254.

- Restores the Reboot button when a device regains xAPI support after going offline (was previously lost permanently until adapter restart)
- Extends the reboot grace period to 3 minutes, covering the monitoring-pause request from QA
- Replaces the raw Webex error dialog with a readable, device-named message when reboot fails
- Exposes device state (e.g. Sleeping/InCall) as a property, at no extra API cost, for visibility during reboot

Not included in this PR:
- The literal 3-minute button-lock behavior originally requested — gracePeriod's actual mechanism is still under discussion with the team
- A separate fix for the Reboot control becoming unresponsive under load — root-caused to lock contention in doGetWithRetry(); a P1 has been filed on dal-commons to fix the underlying retry-strategy issue at the source, and any adapter-side workaround is on hold pending that
- The date-range error QA reported separately — confirmed not originating from this adapter; still being traced

Commits:
- d5b7d8b — Restore Reboot control after xAPI support is regained
- a64e59d — Extend reboot grace period to 3 minutes
- 0239c27 — Show readable error when reboot command fails
- 7e6821a — Expose device state unconditionally for reboot visibility